### PR TITLE
Add sorting to price list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,27 @@ or get in touch with us on [Twitter](https://twitter.com/getlionshare).
 
 _Special thanks to [Coinbase](http://coinbase.com/) for sponsoring the release of Lionshare as open source software. If you’re interested in building products to reinvent the future of finance, [get in touch](https://www.coinbase.com/careers)._
 
+
 ## Development
 
 Electron specific code, including application configuration and Webpack build files,
 can be found under `desktop/`. All React application code is stored inside `src/`.
 
+### Installation
+
+To install for development, clone the repository and install the dependencies with `yarn`.
+
+```bash
+$ git clone git@github.com:lionsharecapital/lionshare-desktop.gitfd$a
+$ cd lionshare-desktop
+$ yarn 
+```
+
+### Running
+
 To run development application and Webpack server:
 
 ```
-yarn
 yarn run dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "chart.js": "^2.4",
     "classnames": "^2.2.5",
-    "concurrently": "^3.1.0",
+    "concurrently": "^3.3.0",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",
     "dotenv": "^2.0.0",

--- a/src/scenes/Prices/Prices.js
+++ b/src/scenes/Prices/Prices.js
@@ -19,6 +19,7 @@ class Prices extends React.Component {
     } = this.props.prices;
     const {
       visibleCurrencies,
+      sortBy
     } = this.props.ui;
 
     return (
@@ -30,6 +31,7 @@ class Prices extends React.Component {
           <PriceList
             assets={ priceListData }
             visibleCurrencies={ visibleCurrencies }
+            sortBy={ sortBy }
           />
         ) }
       </Layout>

--- a/src/scenes/Prices/components/PriceList/PriceList.js
+++ b/src/scenes/Prices/components/PriceList/PriceList.js
@@ -2,8 +2,10 @@ import React from 'react';
 import { Flex } from 'reflexbox';
 import { observer } from 'mobx-react';
 import { Line } from 'react-chartjs-2';
+import numeral from 'numeral';
 
 import { formatNumber } from 'utils/formatting';
+import { sortByType } from 'utils/sortBy';
 
 import CurrencyColor from 'components/CurrencyColor';
 import ChangeHighlight from 'components/ChangeHighlight';
@@ -13,12 +15,13 @@ import classNames from 'classnames/bind';
 import styles from './PriceList.scss';
 const cx = classNames.bind(styles);
 
-const PriceList = ({ assets, visibleCurrencies }) => {
+const PriceList = ({ assets, visibleCurrencies, sortBy }) => {
   const includedAssets = assets.filter(asset => visibleCurrencies.includes(asset.symbol));
+  const sorted = sortByType(includedAssets, sortBy);
 
   return (
     <Flex auto column className={ styles.container }>
-      { includedAssets.map(asset => (
+      { sorted.map(asset => (
         <AssetRow
           key={ asset.symbol }
           { ...asset }
@@ -105,7 +108,7 @@ const AssetRow = ({
           </Flex>
           <Flex justify="space-between" className={ styles.cap }>
             <span className={ styles.label }>M</span>
-            <span>${ marketCap }</span>
+            <span>${ numeral(marketCap).format('0.0a') }</span>
           </Flex>
         </Flex>
       </Flex>

--- a/src/scenes/Settings/Settings.js
+++ b/src/scenes/Settings/Settings.js
@@ -59,22 +59,16 @@ class Settings extends React.Component {
             <Heading>Sort currencies by</Heading>
             <SettingToggle>
               <ToggleOption
-                onClick={ () => { selectSortBy(SORT_TYPES.default) } }
-                selected={ sortBy === SORT_TYPES.default }
-              >
-                Default
-              </ToggleOption>
-              <ToggleOption
                 onClick={ () => { selectSortBy(SORT_TYPES.marketCap) } }
                 selected={ sortBy === SORT_TYPES.marketCap }
               >
                 Market Cap
               </ToggleOption>
               <ToggleOption
-                onClick={ () => { selectSortBy(SORT_TYPES.price) } }
-                selected={ sortBy === SORT_TYPES.price }
+                onClick={ () => { selectSortBy(SORT_TYPES.change) } }
+                selected={ sortBy === SORT_TYPES.change }
               >
-                Price
+                % Change Today
               </ToggleOption>
             </SettingToggle>
           </Section>

--- a/src/scenes/Settings/Settings.js
+++ b/src/scenes/Settings/Settings.js
@@ -4,6 +4,7 @@ import { Flex } from 'reflexbox';
 import { shell } from 'electron';
 
 import { CURRENCIES } from 'utils/currencies';
+import { SORT_TYPES } from 'utils/sortBy';
 
 import Layout from 'components/Layout';
 import CurrencyColor from 'components/CurrencyColor';
@@ -26,6 +27,7 @@ class Settings extends React.Component {
     const periodDay = () => selectPeriod('day');
     const periodWeek = () => selectPeriod('week');
     const periodMonth = () => selectPeriod('month');
+    const { selectSortBy, sortBy } = this.props.ui;
 
     return (
       <Layout footer alwaysLoad>
@@ -50,6 +52,29 @@ class Settings extends React.Component {
                 selected={ period === 'month' }
               >
                 1 Month
+              </ToggleOption>
+            </SettingToggle>
+          </Section>
+          <Section>
+            <Heading>Sort currencies by</Heading>
+            <SettingToggle>
+              <ToggleOption
+                onClick={ () => { selectSortBy(SORT_TYPES.default) } }
+                selected={ sortBy === SORT_TYPES.default }
+              >
+                Default
+              </ToggleOption>
+              <ToggleOption
+                onClick={ () => { selectSortBy(SORT_TYPES.marketCap) } }
+                selected={ sortBy === SORT_TYPES.marketCap }
+              >
+                Market Cap
+              </ToggleOption>
+              <ToggleOption
+                onClick={ () => { selectSortBy(SORT_TYPES.price) } }
+                selected={ sortBy === SORT_TYPES.price }
+              >
+                Price
               </ToggleOption>
             </SettingToggle>
           </Section>

--- a/src/stores/PricesStore.js
+++ b/src/stores/PricesStore.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import numeral from 'numeral';
 import { observable, computed, action, autorun } from 'mobx';
 import ReconnectingWebsocket from 'reconnecting-websocket';
 
@@ -157,7 +156,7 @@ export default class PricesStore {
   marketCap = (currency) => {
     const marketCap = 0.0;
     if (this.isLoaded) {
-      return numeral(this.marketData[currency]).format('0.0a');
+      return this.marketData[currency];
     }
     return marketCap;
   }

--- a/src/stores/UiStore.js
+++ b/src/stores/UiStore.js
@@ -1,5 +1,6 @@
 import { observable, action, autorun } from 'mobx';
 import { CURRENCIES } from 'utils/currencies';
+import { SORT_TYPES } from 'utils/sortBy';
 
 const UI_STORE_KEY = 'UI_STORE_KEY';
 const AVAILABLE_VIEWS = [
@@ -11,6 +12,7 @@ const AVAILABLE_VIEWS = [
 export default class Ui {
   @observable view = AVAILABLE_VIEWS[0];
   @observable visibleCurrencies = CURRENCIES.map(currency => currency.symbol);
+  @observable sortBy = SORT_TYPES.default;
 
   /* actions */
 
@@ -28,6 +30,10 @@ export default class Ui {
     }
   }
 
+  @action selectSortBy = (sortBy) => {
+    this.sortBy = sortBy;
+  };
+
   @action toggleCurrenciesAll = () => {
     this.toggleCurrenciesNone(); // Clear first
     CURRENCIES.forEach(currency => this.visibleCurrencies.push(currency.symbol));
@@ -41,6 +47,7 @@ export default class Ui {
     const parsed = JSON.parse(jsonData);
     this.view = parsed.view;
     this.visibleCurrencies.replace(parsed.visibleCurrencies);
+    this.sortBy = parsed.sortBy || this.sortBy;
   }
 
   /* other */
@@ -49,6 +56,7 @@ export default class Ui {
     JSON.stringify({
       view: this.view,
       visibleCurrencies: this.visibleCurrencies,
+      sortBy: this.sortBy,
     })
   )
 

--- a/src/stores/UiStore.js
+++ b/src/stores/UiStore.js
@@ -12,7 +12,7 @@ const AVAILABLE_VIEWS = [
 export default class Ui {
   @observable view = AVAILABLE_VIEWS[0];
   @observable visibleCurrencies = CURRENCIES.map(currency => currency.symbol);
-  @observable sortBy = SORT_TYPES.default;
+  @observable sortBy = SORT_TYPES.marketCap;
 
   /* actions */
 

--- a/src/utils/sortBy.js
+++ b/src/utils/sortBy.js
@@ -1,0 +1,18 @@
+import _sortBy from 'lodash/sortBy';
+
+export const SORT_TYPES = {
+  marketCap: 'marketCap',
+  price: 'price',
+  default: null,
+};
+
+export function sortByType(priceList, sortBy) {
+  switch (sortBy) {
+    case SORT_TYPES.marketCap:
+      return _sortBy(priceList, x => -x.marketCap);
+    case SORT_TYPES.price:
+      return _sortBy(priceList, x => -x.price);
+    default:
+      return priceList;
+  }
+}

--- a/src/utils/sortBy.js
+++ b/src/utils/sortBy.js
@@ -2,16 +2,15 @@ import _sortBy from 'lodash/sortBy';
 
 export const SORT_TYPES = {
   marketCap: 'marketCap',
-  price: 'price',
-  default: null,
+  change: 'change',
 };
 
 export function sortByType(priceList, sortBy) {
   switch (sortBy) {
     case SORT_TYPES.marketCap:
       return _sortBy(priceList, x => -x.marketCap);
-    case SORT_TYPES.price:
-      return _sortBy(priceList, x => -x.price);
+    case SORT_TYPES.change:
+      return _sortBy(priceList, x => -Math.abs(x.change));
     default:
       return priceList;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,10 +1114,6 @@ bluebird-lst-c@^1.0.6:
   dependencies:
     bluebird "^3.4.7"
 
-bluebird@2.9.6:
-  version "2.9.6"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.6.tgz#1fc3a6b1685267dc121b5ec89b32ce069d81ab7d"
-
 bluebird@^2.9.33:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
@@ -1460,17 +1456,17 @@ concat-stream@^1.4.6:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concurrently@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-3.1.0.tgz#dc5ef0459090012604756668894c04b434ef90d1"
+concurrently@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-3.3.0.tgz#d8eb7a9765fdf0b28d12220dc058e14d03c7dd4f"
   dependencies:
-    bluebird "2.9.6"
     chalk "0.5.1"
     commander "2.6.0"
+    date-fns "^1.23.0"
     lodash "^4.5.1"
-    moment "^2.11.2"
     rx "2.3.24"
-    spawn-default-shell "^1.1.0"
+    spawn-command "^0.0.2-1"
+    supports-color "^3.2.3"
     tree-kill "^1.1.0"
 
 conf@^0.11.1:
@@ -1694,6 +1690,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.23.0:
+  version "1.27.2"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.27.2.tgz#ce82f420bc028356cc661fc55c0494a56a990c9c"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -3589,7 +3589,7 @@ mobx@^2.2.2:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-2.7.0.tgz#cf3d82d18c0ca7f458d8f2a240817b3dc7e54a01"
 
-moment@^2.10.6, moment@^2.11.2:
+moment@^2.10.6:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
 
@@ -4928,9 +4928,9 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, sour
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-spawn-default-shell@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/spawn-default-shell/-/spawn-default-shell-1.1.0.tgz#095439d44c4b7c0aff56a53929fbaab87878e7c6"
+spawn-command@^0.0.2-1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2.tgz#9544e1a43ca045f8531aac1a48cb29bdae62338e"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -5094,6 +5094,12 @@ supports-color@^2.0.0:
 supports-color@^3.1.0, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  dependencies:
+    has-flag "^1.0.0"
+
+supports-color@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
 


### PR DESCRIPTION
This PR addresses #48 by adding sorting to the price list. With these changes, users will be able to sort by:

* Market Cap
* Price
* Default (i.e. whatever the APIs return)

Some things I'd like feedback on:

1. The naming of "default" seems a little weird - any thoughts on this?
2. The second part of #48 is adding the ability for users to manually arrange. I'd like to do this and think it could actually fall nicely under the "default" setting -- maybe we could change the name to "Manual" when we add that functionality?

cc @jorilallo @jenbennings
