### PR TITLE
fix dot style

### DIFF
--- a/src/components/CurrencyColor/CurrencyColor.scss
+++ b/src/components/CurrencyColor/CurrencyColor.scss
@@ -1,5 +1,5 @@
 .container {
-  width: 13px;
-  height: 13px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
 }

--- a/src/scenes/Prices/components/PriceList/PriceList.scss
+++ b/src/scenes/Prices/components/PriceList/PriceList.scss
@@ -15,12 +15,12 @@
 }
 
 .rowLeft {
-  padding: 15px;
+  padding: 13px;
   padding-right: 0px;
 }
 
 .rowRight {
-  padding: 15px;
+  padding: 13px;
   padding-left: 0px;
 
   &:hover {


### PR DESCRIPTION
In my opinion it's looks better, when the dot size equal to system dot size 💅 

Before:
![before](https://cloud.githubusercontent.com/assets/922338/24405053/1fbc5182-13cc-11e7-8851-c13bfd118ec6.png)
After:
![after](https://cloud.githubusercontent.com/assets/922338/24405056/21d1a6a2-13cc-11e7-9c13-c08c5cdcb157.png)