### PR TITLE
fix currency format for different locale

### DIFF
--- a/src/utils/formatting.js
+++ b/src/utils/formatting.js
@@ -1,17 +1,22 @@
-import numeral from 'numeral';
-
 const formatNumber = (amount, currency, options = {}) => {
-  if (!(options.maximumFractionDigits || options.maximumFractionDigits === 0)) {
+  if (
+    !(options.maximumFractionDigits || options.maximumFractionDigits === 0) &&
+    currency
+  ) {
     options.maximumFractionDigits = Math.max(
       0,
       7 - parseInt(amount, 10).toString().length
     );
   }
 
-  let value = new Intl.NumberFormat(navigator.language, {
-    style: 'decimal',
-    ...options,
-  }).format(Math.abs(amount));
+  if (!currency || options.minPrecision) {
+    options.maximumFractionDigits = 2;
+    options.minimumFractionDigits = 2;
+  }
+
+  let value = new Intl.NumberFormat(navigator.language, options).format(
+    Math.abs(amount)
+  );
 
   if (currency) {
     value = `$${value}`;
@@ -20,17 +25,6 @@ const formatNumber = (amount, currency, options = {}) => {
   if (options.directionSymbol) {
     const direction = amount >= 0.0 ? '+' : '-';
     value = `${direction}${value}`;
-  }
-
-  if (options.minPrecision) {
-    // Set min precision
-    value = value.replace(/\d+(?:,\d+)*(?:\.\d+)?/, match => {
-      const matchValue = parseFloat(match.replace(/,/g, ''));
-      if (matchValue >= 0.1 || options.directionSymbol) {
-        match = numeral(matchValue).format('0,0.00');
-      }
-      return match;
-    });
   }
 
   return value;


### PR DESCRIPTION
Locale currency was breaking by `numeraljs` and regex. 
I tried to fix it using only native `Intl.NumberFormat`.
But they are open question about currency symbol position. In some localization, symbol staying in the end of digits and it break the app design.
fix #64 #50