### PR TITLE
Add support OmiseGO currencies

### DIFF
--- a/src/utils/currencies.js
+++ b/src/utils/currencies.js
@@ -126,6 +126,11 @@ const CURRENCIES = [
     symbol: 'GNT',
     color: '#01d3e0',
   },
+  {
+    name: 'OmiseGO',
+    symbol: 'OMG',
+    color: '#99ccff',
+  },
 ];
 
 const currencyData = currencySymbol =>


### PR DESCRIPTION
OmiseGO was added to the list of currencies
supported by `lionshare` desktop.